### PR TITLE
参加者新規登録処理の実装

### DIFF
--- a/architecture/PrahaChallenge/backend/src/app.module.ts
+++ b/architecture/PrahaChallenge/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { GetAllAttendeesUsecase } from './app/get-all-attendees/usecase';
 import { PairRepository } from './infrastructure/repository/pair/repository';
 import { TeamRepository } from './infrastructure/repository/team/repository';
 import { PairMemberAssigner } from './domain/pair/pair-member-assigner';
+import { AddNewAttendeeUsecase } from './app/add-new-attendee/usecase';
 
 @Module({
   imports: [],
@@ -28,6 +29,7 @@ import { PairMemberAssigner } from './domain/pair/pair-member-assigner';
       useClass: TeamRepository,
     },
     GetAllAttendeesUsecase,
+    AddNewAttendeeUsecase,
     GetAllTeamsUsecase,
     GetAllPairsUsecase,
     PairMemberAssigner,

--- a/architecture/PrahaChallenge/backend/src/app.module.ts
+++ b/architecture/PrahaChallenge/backend/src/app.module.ts
@@ -11,7 +11,7 @@ import { PairRepository } from './infrastructure/repository/pair/repository';
 import { TeamRepository } from './infrastructure/repository/team/repository';
 import { PairMemberAssigner } from './domain/pair/pair-member-assigner';
 import { AddNewAttendeeUsecase } from './app/add-new-attendee/usecase';
-import { AttendeeService } from './domain/attendee/service';
+import { DuplicatedEmailChecker } from './domain/attendee/duplicated-email-checker';
 
 @Module({
   imports: [],
@@ -34,7 +34,7 @@ import { AttendeeService } from './domain/attendee/service';
     GetAllTeamsUsecase,
     GetAllPairsUsecase,
     PairMemberAssigner,
-    AttendeeService,
+    DuplicatedEmailChecker,
   ],
 })
 export class AppModule {}

--- a/architecture/PrahaChallenge/backend/src/app.module.ts
+++ b/architecture/PrahaChallenge/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { PROVIDERS } from './constants';
 import { GetAllAttendeesUsecase } from './app/get-all-attendees/usecase';
 import { PairRepository } from './infrastructure/repository/pair/repository';
 import { TeamRepository } from './infrastructure/repository/team/repository';
+import { PairMemberAssigner } from './domain/pair/pair-member-assigner';
 
 @Module({
   imports: [],
@@ -29,6 +30,7 @@ import { TeamRepository } from './infrastructure/repository/team/repository';
     GetAllAttendeesUsecase,
     GetAllTeamsUsecase,
     GetAllPairsUsecase,
+    PairMemberAssigner,
   ],
 })
 export class AppModule {}

--- a/architecture/PrahaChallenge/backend/src/app.module.ts
+++ b/architecture/PrahaChallenge/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { PairRepository } from './infrastructure/repository/pair/repository';
 import { TeamRepository } from './infrastructure/repository/team/repository';
 import { PairMemberAssigner } from './domain/pair/pair-member-assigner';
 import { AddNewAttendeeUsecase } from './app/add-new-attendee/usecase';
+import { AttendeeService } from './domain/attendee/service';
 
 @Module({
   imports: [],
@@ -33,6 +34,7 @@ import { AddNewAttendeeUsecase } from './app/add-new-attendee/usecase';
     GetAllTeamsUsecase,
     GetAllPairsUsecase,
     PairMemberAssigner,
+    AttendeeService,
   ],
 })
 export class AppModule {}

--- a/architecture/PrahaChallenge/backend/src/app/add-new-attendee/usecase.spec.ts
+++ b/architecture/PrahaChallenge/backend/src/app/add-new-attendee/usecase.spec.ts
@@ -1,0 +1,88 @@
+import { DuplicatedEmailChecker } from '../../domain/attendee/duplicated-email-checker';
+import { Email } from '../../domain/email/model';
+import { PairMemberAssigner } from '../../domain/pair/pair-member-assigner';
+import {
+  MockAttendeeRepository,
+  MockPairRepository,
+  MockTeamRepository,
+} from '../../mocks/repositories';
+
+import { AddNewAttendeeUsecase } from './usecase';
+
+describe('AddNewAttendeeUseCase', () => {
+  class MockDuplicatedEmailChecker extends DuplicatedEmailChecker {
+    public constructor() {
+      super(MockAttendeeRepository());
+    }
+  }
+
+  class MockPairMemberAssigner extends PairMemberAssigner {
+    public constructor() {
+      super(MockTeamRepository(), MockPairRepository());
+    }
+  }
+
+  beforeAll(() => {
+    MockPairMemberAssigner.prototype.assign = jest
+      .fn()
+      .mockResolvedValueOnce(void 0);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('新規参加者のメールアドレスが既に登録されている場合、エラーが返される', () => {
+    MockDuplicatedEmailChecker.prototype.isDuplicated = jest
+      .fn()
+      .mockResolvedValueOnce(true);
+
+    const usecase = new AddNewAttendeeUsecase(
+      new MockDuplicatedEmailChecker(),
+      new MockAttendeeRepository(),
+      new MockPairMemberAssigner(),
+    );
+
+    expect(
+      usecase.do({ name: 'test', email: new Email('test@test.com') }),
+    ).rejects.toThrowError(`Duplicated email: test@test.com`);
+  });
+
+  test('新規参加者のメールアドレスが既に登録されていない場合、AttendeeRepositoryにinsertされる', async () => {
+    const mockAttendeeRepository = new MockAttendeeRepository();
+
+    const usecase = new AddNewAttendeeUsecase(
+      new MockDuplicatedEmailChecker(),
+      mockAttendeeRepository,
+      new MockPairMemberAssigner(),
+    );
+    MockDuplicatedEmailChecker.prototype.isDuplicated = jest
+      .fn()
+      .mockResolvedValueOnce(false);
+
+    await usecase.do({
+      name: 'test',
+      email: new Email('test@test.com'),
+    });
+    expect(mockAttendeeRepository.insert).toBeCalled();
+  });
+
+  test('新規参加者のメールアドレスが既に登録されていない場合、ペアに配属される', async () => {
+    const mockPairMemberAssigner = new MockPairMemberAssigner();
+
+    const usecase = new AddNewAttendeeUsecase(
+      new MockDuplicatedEmailChecker(),
+      new MockAttendeeRepository(),
+      mockPairMemberAssigner,
+    );
+    MockDuplicatedEmailChecker.prototype.isDuplicated = jest
+      .fn()
+      .mockResolvedValueOnce(false);
+
+    await usecase.do({
+      name: 'test',
+      email: new Email('test@test.com'),
+    });
+    expect(mockPairMemberAssigner.assign).toBeCalled();
+  });
+});

--- a/architecture/PrahaChallenge/backend/src/app/add-new-attendee/usecase.ts
+++ b/architecture/PrahaChallenge/backend/src/app/add-new-attendee/usecase.ts
@@ -3,15 +3,19 @@ import { Email } from '../../domain/email/model';
 import { IAttendeeRepository } from '../../domain/attendee/repository';
 import { Attendee } from '../../domain/attendee/model';
 import { PairMemberAssigner } from '../../domain/pair/pair-member-assigner';
+import { Inject, Injectable } from '@nestjs/common';
+import { PROVIDERS } from '../../constants';
 
 export interface AddNewAttendeeCommand {
   name: string;
   email: Email;
 }
 
+@Injectable()
 export class AddNewAttendeeUsecase {
   constructor(
     private readonly attendeeService: AttendeeService,
+    @Inject(PROVIDERS.ATTENDEE_REPOSITORY)
     private readonly attendeeRepository: IAttendeeRepository,
     private readonly pairMemberAssigner: PairMemberAssigner,
   ) {}

--- a/architecture/PrahaChallenge/backend/src/app/add-new-attendee/usecase.ts
+++ b/architecture/PrahaChallenge/backend/src/app/add-new-attendee/usecase.ts
@@ -2,6 +2,7 @@ import { AttendeeService } from './../../domain/attendee/service';
 import { Email } from '../../domain/email/model';
 import { IAttendeeRepository } from '../../domain/attendee/repository';
 import { Attendee } from '../../domain/attendee/model';
+import { PairMemberAssigner } from '../../domain/pair/pair-member-assigner';
 
 export interface AddNewAttendeeCommand {
   name: string;
@@ -12,6 +13,7 @@ export class AddNewAttendeeUsecase {
   constructor(
     private readonly attendeeService: AttendeeService,
     private readonly attendeeRepository: IAttendeeRepository,
+    private readonly pairMemberAssigner: PairMemberAssigner,
   ) {}
   public async do(command: AddNewAttendeeCommand) {
     const isDuplicatedEmail = await this.attendeeService.isDuplicatedEmail(
@@ -21,7 +23,7 @@ export class AddNewAttendeeUsecase {
       throw new Error(`Duplicated email: ${command.email.value}`);
     }
     const newAttendee = Attendee.create({ ...command });
-    await this.attendeeRepository.save(newAttendee);
-    // TODO: add attendee to team and pair
+    await this.attendeeRepository.insert(newAttendee);
+    await this.pairMemberAssigner.assign(newAttendee);
   }
 }

--- a/architecture/PrahaChallenge/backend/src/app/add-new-attendee/usecase.ts
+++ b/architecture/PrahaChallenge/backend/src/app/add-new-attendee/usecase.ts
@@ -1,10 +1,10 @@
-import { AttendeeService } from './../../domain/attendee/service';
 import { Email } from '../../domain/email/model';
 import { IAttendeeRepository } from '../../domain/attendee/repository';
 import { Attendee } from '../../domain/attendee/model';
 import { PairMemberAssigner } from '../../domain/pair/pair-member-assigner';
 import { Inject, Injectable } from '@nestjs/common';
 import { PROVIDERS } from '../../constants';
+import { DuplicatedEmailChecker } from '../../domain/attendee/duplicated-email-checker';
 
 export interface AddNewAttendeeCommand {
   name: string;
@@ -14,13 +14,13 @@ export interface AddNewAttendeeCommand {
 @Injectable()
 export class AddNewAttendeeUsecase {
   constructor(
-    private readonly attendeeService: AttendeeService,
+    private readonly duplicatedEmailChecker: DuplicatedEmailChecker,
     @Inject(PROVIDERS.ATTENDEE_REPOSITORY)
     private readonly attendeeRepository: IAttendeeRepository,
     private readonly pairMemberAssigner: PairMemberAssigner,
   ) {}
   public async do(command: AddNewAttendeeCommand) {
-    const isDuplicatedEmail = await this.attendeeService.isDuplicatedEmail(
+    const isDuplicatedEmail = await this.duplicatedEmailChecker.isDuplicated(
       command.email,
     );
     if (isDuplicatedEmail) {

--- a/architecture/PrahaChallenge/backend/src/app/get-all-attendees/usecase.spec.ts
+++ b/architecture/PrahaChallenge/backend/src/app/get-all-attendees/usecase.spec.ts
@@ -1,6 +1,6 @@
 import { Attendee } from '../../domain/attendee/model';
 import { Email } from '../../domain/email/model';
-import { IAttendeeRepository } from './../../domain/attendee/repository';
+import { MockAttendeeRepository } from '../../mocks/repositories';
 import { GetAllAttendeesDto, GetAllAttendeesUsecase } from './usecase';
 
 const attendees: Attendee[] = [
@@ -15,24 +15,16 @@ const attendees: Attendee[] = [
 ];
 
 describe('GetAllPairsUsecase', () => {
-  const mockFindAll = jest.fn().mockReturnValue(Promise.resolve(attendees));
-  const mockFindByEmail = jest.fn();
-  const mockSave = jest.fn();
-  const mockRepository = jest
-    .fn<IAttendeeRepository, []>()
-    .mockImplementation(() => ({
-      findAll: mockFindAll,
-      findByEmail: mockFindByEmail,
-      save: mockSave,
-    }));
-
   afterEach(() => {
-    mockFindAll.mockClear();
+    jest.restoreAllMocks();
   });
 
   test('AllAttendeesDtoを返す', () => {
-    const getAllAttendeesUseCase = new GetAllAttendeesUsecase(mockRepository());
-    // maybe this is not good way to assert.
+    const mockAttendeeRepository = new MockAttendeeRepository();
+    mockAttendeeRepository.findAll = jest.fn().mockResolvedValueOnce(attendees);
+    const getAllAttendeesUseCase = new GetAllAttendeesUsecase(
+      mockAttendeeRepository,
+    );
     expect(getAllAttendeesUseCase.do()).resolves.toEqual(
       new GetAllAttendeesDto(attendees),
     );

--- a/architecture/PrahaChallenge/backend/src/controller/attendee/attendee.controller.ts
+++ b/architecture/PrahaChallenge/backend/src/controller/attendee/attendee.controller.ts
@@ -1,17 +1,16 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { ApiResponse } from '@nestjs/swagger';
 import { GetAllAttendeesResponse } from './response/getAllAttendeesResponse';
 import { GetAllAttendeesUsecase } from '../../app/get-all-attendees/usecase';
-
-export type AddNewAttendeeRequest = {
-  name: string;
-  email: string;
-};
+import { AddNewAttendeeAdaptor } from './request/AddNewAttendeeAdaptor';
+import { AddNewAttendeeUsecase } from '../../app/add-new-attendee/usecase';
+import { AddNewAttendeeRequest } from './request/AddNewAttendeeRequest';
 
 @Controller('attendee')
 export class AttendeeController {
   constructor(
     private readonly getAllAttendeesUsecase: GetAllAttendeesUsecase,
+    private readonly addNewAttendeeUsecase: AddNewAttendeeUsecase,
   ) {}
 
   @Get()
@@ -22,12 +21,12 @@ export class AttendeeController {
     return response;
   }
 
-  // @Post()
-  // @ApiResponse({ status: 200 })
-  // addNewAttendee(@Body() request: AddNewAttendeeRequest) {
-  //   const command = AddNewAttendeeAdaptor.toCommand(request);
-  //   const usecase = new AddNewAttendeeUsecase();
-  //   usecase.do(command);
-  //   return;
-  // }
+  @Post()
+  @ApiResponse({ status: 200 })
+  async addNewAttendee(@Body() request: AddNewAttendeeRequest) {
+    const command = AddNewAttendeeAdaptor.toCommand(request);
+    await this.addNewAttendeeUsecase.do(command);
+    //TODO: error handling
+    return;
+  }
 }

--- a/architecture/PrahaChallenge/backend/src/controller/attendee/request/AddNewAttendeeAdaptor.ts
+++ b/architecture/PrahaChallenge/backend/src/controller/attendee/request/AddNewAttendeeAdaptor.ts
@@ -1,6 +1,6 @@
 import { AddNewAttendeeCommand } from '../../../app/add-new-attendee/usecase';
 import { Email } from '../../../domain/email/model';
-import { AddNewAttendeeRequest } from '../attendee.controller';
+import { AddNewAttendeeRequest } from './AddNewAttendeeRequest';
 
 export const AddNewAttendeeAdaptor = {
   toCommand(request: AddNewAttendeeRequest): AddNewAttendeeCommand {

--- a/architecture/PrahaChallenge/backend/src/controller/attendee/request/AddNewAttendeeRequest.ts
+++ b/architecture/PrahaChallenge/backend/src/controller/attendee/request/AddNewAttendeeRequest.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AddNewAttendeeRequest {
+  @ApiProperty()
+  name: string;
+  @ApiProperty()
+  email: string;
+}

--- a/architecture/PrahaChallenge/backend/src/domain/attendee/duplicated-email-checker.spec.ts
+++ b/architecture/PrahaChallenge/backend/src/domain/attendee/duplicated-email-checker.spec.ts
@@ -1,0 +1,38 @@
+import { MockAttendeeRepository } from '../../mocks/repositories';
+import { Email } from '../email/model';
+import { DuplicatedEmailChecker } from './duplicated-email-checker';
+import { Attendee } from './model';
+
+describe('DuplicatedEmailChecker', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('同じEmailを持つ参加者が存在する場合、isDuplicatedはtrueを返す', () => {
+    const mockAttendeeRepository = new MockAttendeeRepository();
+    const attendee = Attendee.create({
+      name: 'test',
+      email: new Email('test@test.com'),
+    });
+    mockAttendeeRepository.findByEmail = jest
+      .fn()
+      .mockResolvedValueOnce(attendee);
+    const duplicatedEmailChecker = new DuplicatedEmailChecker(
+      mockAttendeeRepository,
+    );
+    expect(
+      duplicatedEmailChecker.isDuplicated(new Email('test@test.com')),
+    ).resolves.toBeTruthy();
+  });
+
+  test('同じEmailを持つ参加者が存在しない場合、isDuplicatedはfalseを返す', () => {
+    const mockAttendeeRepository = new MockAttendeeRepository();
+    mockAttendeeRepository.findByEmail = jest.fn().mockResolvedValueOnce(null);
+    const duplicatedEmailChecker = new DuplicatedEmailChecker(
+      mockAttendeeRepository,
+    );
+    expect(
+      duplicatedEmailChecker.isDuplicated(new Email('test@test.com')),
+    ).resolves.toBeFalsy();
+  });
+});

--- a/architecture/PrahaChallenge/backend/src/domain/attendee/duplicated-email-checker.ts
+++ b/architecture/PrahaChallenge/backend/src/domain/attendee/duplicated-email-checker.ts
@@ -3,12 +3,12 @@ import { Email } from '../email/model';
 import { Inject, Injectable } from '@nestjs/common';
 
 @Injectable()
-export class AttendeeService {
+export class DuplicatedEmailChecker {
   public constructor(
     @Inject('AttendeeRepository')
     private attendeeRepository: IAttendeeRepository,
   ) {}
-  public async isDuplicatedEmail(email: Email): Promise<boolean> {
+  public async isDuplicated(email: Email): Promise<boolean> {
     const attendee = await this.attendeeRepository.findByEmail(email);
     return attendee ? true : false;
   }

--- a/architecture/PrahaChallenge/backend/src/domain/attendee/repository.ts
+++ b/architecture/PrahaChallenge/backend/src/domain/attendee/repository.ts
@@ -4,5 +4,5 @@ import { Attendee } from './model';
 export interface IAttendeeRepository {
   findByEmail(email: Email): Promise<Attendee | null>;
   findAll(): Promise<Attendee[]>;
-  save(attendee: Attendee): Promise<void>;
+  insert(attendee: Attendee): Promise<void>;
 }

--- a/architecture/PrahaChallenge/backend/src/domain/pair/pair-member-assigner.spec.ts
+++ b/architecture/PrahaChallenge/backend/src/domain/pair/pair-member-assigner.spec.ts
@@ -1,0 +1,96 @@
+import {
+  MockPairRepository,
+  MockTeamRepository,
+} from '../../mocks/repositories';
+import { Attendee } from '../attendee/model';
+import { Email } from '../email/model';
+import { AttendeeId, PairId } from '../id/model';
+import { PairName } from '../pair-name/model';
+import { TeamName } from '../team-name/model';
+import { Team } from '../team/model';
+import { Pair } from './model';
+import { PairMemberAssigner } from './pair-member-assigner';
+
+const testData = {
+  team: {
+    teamWithLeastAttendees: Team.create({
+      name: new TeamName(2),
+      pairIds: ['pair4', 'pair5'].map((pairId) => new PairId(pairId)),
+    }),
+    getAllTeams: function () {
+      return [
+        Team.create({
+          name: new TeamName(1),
+          pairIds: ['pair1', 'pair2', 'pair3'].map(
+            (pairId) => new PairId(pairId),
+          ),
+        }),
+      ].concat(this.teamWithLeastAttendees);
+    },
+  },
+  pair: {
+    pairWithLeastAttendees: Pair.create({
+      name: new PairName('c'),
+      pairMemberAttendeeIds: ['attendeeId4', 'attendeeId5'].map(
+        (attendeeId) => new AttendeeId(attendeeId),
+      ),
+    }),
+    getPairsByIds: function () {
+      return [
+        Pair.create({
+          name: new PairName('a'),
+          pairMemberAttendeeIds: [
+            'attendeeId1',
+            'attendeeId2',
+            'attendeeId3',
+          ].map((attendeeId) => new AttendeeId(attendeeId)),
+        }),
+      ].concat(this.pairWithLeastAttendees);
+    },
+  },
+  attendee: {
+    newAttendee: Attendee.create({
+      name: 'test',
+      email: new Email('test@test.com'),
+    }),
+  },
+} as const;
+
+describe('PairMemberAssigner', () => {
+  const mockTeamRepository = new MockTeamRepository();
+  const mockPairRepository = new MockPairRepository();
+  let pairMemberAssigner: PairMemberAssigner;
+
+  beforeEach(() => {
+    mockTeamRepository.findAll = jest
+      .fn()
+      .mockResolvedValue(testData.team.getAllTeams());
+    mockPairRepository.findByIds = jest
+      .fn()
+      .mockResolvedValue(testData.pair.getPairsByIds());
+    pairMemberAssigner = new PairMemberAssigner(
+      mockTeamRepository,
+      mockPairRepository,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('人数が最も少ないチームの中の、人数が最も少ないペアに新規参加者が配属される', async () => {
+    const spiedGetPairWithLeastAttendees = jest.spyOn(
+      pairMemberAssigner as any,
+      'getPairWithLeastAttendees',
+    );
+    await pairMemberAssigner.assign(testData.attendee.newAttendee);
+    expect(spiedGetPairWithLeastAttendees).toHaveBeenCalledWith(
+      testData.team.teamWithLeastAttendees,
+    );
+    expect(mockPairRepository.update).toHaveBeenCalledWith(
+      testData.pair.pairWithLeastAttendees.addAttendee(
+        testData.attendee.newAttendee.id,
+      ),
+    );
+  });
+});

--- a/architecture/PrahaChallenge/backend/src/domain/pair/pair-member-assigner.ts
+++ b/architecture/PrahaChallenge/backend/src/domain/pair/pair-member-assigner.ts
@@ -1,0 +1,49 @@
+import { Inject } from '@nestjs/common';
+import { PROVIDERS } from '../../constants';
+import { ITeamRepository } from '../../domain/team/repository';
+import { Team } from '../../domain/team/model';
+import { IPairRepository } from '../../domain/pair/repository';
+import { Pair } from './model';
+import { Attendee } from '../attendee/model';
+
+export class PairMemberAssigner {
+  constructor(
+    @Inject(PROVIDERS.TEAM_REPOSITORY)
+    private readonly teamRepository: ITeamRepository,
+    @Inject(PROVIDERS.PAIR_REPOSITORY)
+    private readonly pairRepository: IPairRepository,
+  ) {}
+
+  public async assign({ id: attendeeId }: Attendee) {
+    const teamWithLeastAttendees = await this.getTeamWithLeastAttendees();
+    const pairWithLeastAttendees = await this.getPairWithLeastAttendees(
+      teamWithLeastAttendees,
+    );
+    await this.pairRepository.update(
+      pairWithLeastAttendees.addAttendee(attendeeId),
+    );
+  }
+
+  private async getTeamWithLeastAttendees(): Promise<Team> {
+    const allTeams = await this.teamRepository.findAll();
+    const teamWithLeastAttendees = allTeams.reduce((a, b) =>
+      this.calculateAttendeeCount(a) < this.calculateAttendeeCount(b) ? a : b,
+    );
+    return teamWithLeastAttendees;
+  }
+
+  private async getPairWithLeastAttendees(team: Team): Promise<Pair> {
+    const pairs = await this.pairRepository.findByIds(team.pairIds);
+    const pairWithLeastAttendees = pairs.reduce((a, b) =>
+      a.pairMemberAttendeeIds.length < b.pairMemberAttendeeIds.length ? a : b,
+    );
+    return pairWithLeastAttendees;
+  }
+
+  private async calculateAttendeeCount(team: Team): Promise<number> {
+    const pairs = await this.pairRepository.findByIds(team.pairIds);
+    return pairs
+      .map((pair) => pair.pairMemberAttendeeIds.length)
+      .reduce((a, b) => a + b, 0);
+  }
+}

--- a/architecture/PrahaChallenge/backend/src/domain/pair/repository.ts
+++ b/architecture/PrahaChallenge/backend/src/domain/pair/repository.ts
@@ -1,5 +1,8 @@
+import { PairId } from '../id/model';
 import { Pair } from './model';
 
 export interface IPairRepository {
   findAll(): Promise<Pair[]>;
+  findByIds(pairIds: PairId[]): Promise<Pair[]>;
+  update(pair: Pair): Promise<void>;
 }

--- a/architecture/PrahaChallenge/backend/src/infrastructure/repository/attendee/repository.ts
+++ b/architecture/PrahaChallenge/backend/src/infrastructure/repository/attendee/repository.ts
@@ -64,7 +64,7 @@ export class AttendeeRepository implements IAttendeeRepository {
     );
   }
 
-  public async save(attendee: Attendee): Promise<void> {
+  public async insert(attendee: Attendee): Promise<void> {
     const activeAttendeeStatus = await prisma.attendeeStatus.findFirst({
       where: {
         name: attendee.status,

--- a/architecture/PrahaChallenge/backend/src/mocks/repositories/index.ts
+++ b/architecture/PrahaChallenge/backend/src/mocks/repositories/index.ts
@@ -1,0 +1,23 @@
+import { AttendeeRepository } from '../../infrastructure/repository/attendee/repository';
+import { PairRepository } from '../../infrastructure/repository/pair/repository';
+import { TeamRepository } from '../../infrastructure/repository/team/repository';
+
+const MockAttendeeRepository = jest.fn<AttendeeRepository, []>(() => ({
+  insert: jest.fn(),
+  findAll: jest.fn(),
+  findByEmail: jest.fn(),
+}));
+
+const MockPairRepository = jest.fn<PairRepository, []>(() => ({
+  insert: jest.fn(),
+  findAll: jest.fn(),
+  findByIds: jest.fn(),
+  update: jest.fn(),
+}));
+
+const MockTeamRepository = jest.fn<TeamRepository, []>(() => ({
+  findById: jest.fn(),
+  findAll: jest.fn(),
+}));
+
+export { MockAttendeeRepository, MockPairRepository, MockTeamRepository };


### PR DESCRIPTION
### やったこと
- 新規参加者が登録される処理
- 新規参加者が参加人数が最も少ないチームの中の、ペア人数が最も少ないチームに配属される処理
- UseCase層とDomain層のテスト

### やってないこと
- 各種エラーハンドリング
- エッジケースの対応（チームが1チームも存在しない場合など）

### 見て欲しい箇所
- DDD, オニオンアーキテクチャ的に問題点が無いか（レイヤーの責務、ドメイン知識の表現方法など）
- テストが必要十分か、アサーションが適切か（異常系のテストも本来は書くべきですが、とりあえず正常系のテストのみ書きました）

### そこまでしっかり見なくて良い箇所
- 各種ライブラリの細かい部分（prismaの書き方など）